### PR TITLE
fix: haralick hdiv vdiv bug

### DIFF
--- a/balu3/fx/chr.py
+++ b/balu3/fx/chr.py
@@ -116,10 +116,10 @@ def haralick(img,hdiv=1, vdiv=1, distance=1,norm=False,names=False):
       #haralick = [np.mean(x1),np.mean(x2),np.mean(x3),np.mean(x4),np.mean(x5),np.mean(x6)]
       haralick = np.concatenate((x0,x1,x2,x3,x4,x5), axis=1)
       if k==0:
-        X = haralick[0]
+        X = haralick
         k = 1
       else:
-        X = np.concatenate((X,haralick))
+        X = np.concatenate((X,haralick), axis=0)
   if norm:
     X = X/np.linalg.norm(X)
 
@@ -129,9 +129,9 @@ def haralick(img,hdiv=1, vdiv=1, distance=1,norm=False,names=False):
       for j in range(hdiv):
         for k in range(6):
           Xn.append('Haralick('+str(i)+','+str(j)+')-'+fst[k])
-    return X,Xn
+    return X.flatten(),Xn
   else:
-    return X
+    return X.flatten()
 
 
 


### PR DESCRIPTION
### Bug description

When using `hdiv > 1` or `vdiv > 1`, the `haralick` function raises the following error:

```
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has 2 dimension(s)
```

### Fix

The issue occurs because the arrays returned by `graycoprops` have shape `(1, 4)`, and concatenating them directly requires consistent dimensions. This fix ensures proper axis handling and supports image partitioning.

### Notes

- Backwards compatible for `hdiv=1, vdiv=1`
- Please test the fix before considering a merge